### PR TITLE
Feature/laravel vue collaboration

### DIFF
--- a/backend/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/backend/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\LoginRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class AuthenticatedSessionController extends Controller
+{
+    /**
+     * Display the login view.
+     */
+    public function create(): Response
+    {
+        return Inertia::render('Auth/Login', [
+            'canResetPassword' => Route::has('password.request'),
+            'status' => session('status'),
+        ]);
+    }
+
+    /**
+     * Handle an incoming authentication request.
+     */
+    public function store(LoginRequest $request): RedirectResponse
+    {
+        $request->authenticate();
+
+        $request->session()->regenerate();
+
+        session()->flash('status', 'ログインに成功しました！');
+
+        return redirect()->intended(route('dashboard', absolute: false));
+    }
+
+    /**
+     * Destroy an authenticated session.
+     */
+    public function destroy(Request $request): RedirectResponse
+    {
+        Auth::guard('web')->logout();
+
+        $request->session()->invalidate();
+
+        $request->session()->regenerateToken();
+
+        return redirect('/');
+    }
+}

--- a/backend/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/backend/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ConfirmablePasswordController extends Controller
+{
+    /**
+     * Show the confirm password view.
+     */
+    public function show(): Response
+    {
+        return Inertia::render('Auth/ConfirmPassword');
+    }
+
+    /**
+     * Confirm the user's password.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        if (! Auth::guard('web')->validate([
+            'email' => $request->user()->email,
+            'password' => $request->password,
+        ])) {
+            throw ValidationException::withMessages([
+                'password' => __('auth.password'),
+            ]);
+        }
+
+        $request->session()->put('auth.password_confirmed_at', time());
+
+        return redirect()->intended(route('dashboard', absolute: false));
+    }
+}

--- a/backend/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/backend/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class EmailVerificationNotificationController extends Controller
+{
+    /**
+     * Send a new email verification notification.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        if ($request->user()->hasVerifiedEmail()) {
+            return redirect()->intended(route('dashboard', absolute: false));
+        }
+
+        $request->user()->sendEmailVerificationNotification();
+
+        return back()->with('status', 'verification-link-sent');
+    }
+}

--- a/backend/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/backend/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class EmailVerificationPromptController extends Controller
+{
+    /**
+     * Display the email verification prompt.
+     */
+    public function __invoke(Request $request): RedirectResponse|Response
+    {
+        return $request->user()->hasVerifiedEmail()
+                    ? redirect()->intended(route('dashboard', absolute: false))
+                    : Inertia::render('Auth/VerifyEmail', ['status' => session('status')]);
+    }
+}

--- a/backend/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/backend/app/Http/Controllers/Auth/NewPasswordController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Auth\Events\PasswordReset;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rules;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class NewPasswordController extends Controller
+{
+    /**
+     * Display the password reset view.
+     */
+    public function create(Request $request): Response
+    {
+        return Inertia::render('Auth/ResetPassword', [
+            'email' => $request->email,
+            'token' => $request->route('token'),
+        ]);
+    }
+
+    /**
+     * Handle an incoming new password request.
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'token' => 'required',
+            'email' => 'required|email',
+            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+        ]);
+
+        // Here we will attempt to reset the user's password. If it is successful we
+        // will update the password on an actual user model and persist it to the
+        // database. Otherwise we will parse the error and return the response.
+        $status = Password::reset(
+            $request->only('email', 'password', 'password_confirmation', 'token'),
+            function ($user) use ($request) {
+                $user->forceFill([
+                    'password' => Hash::make($request->password),
+                    'remember_token' => Str::random(60),
+                ])->save();
+
+                event(new PasswordReset($user));
+            }
+        );
+
+        // If the password was successfully reset, we will redirect the user back to
+        // the application's home authenticated view. If there is an error we can
+        // redirect them back to where they came from with their error message.
+        if ($status == Password::PASSWORD_RESET) {
+            return redirect()->route('login')->with('status', __($status));
+        }
+
+        throw ValidationException::withMessages([
+            'email' => [trans($status)],
+        ]);
+    }
+}

--- a/backend/app/Http/Controllers/Auth/PasswordController.php
+++ b/backend/app/Http/Controllers/Auth/PasswordController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules\Password;
+
+class PasswordController extends Controller
+{
+    /**
+     * Update the user's password.
+     */
+    public function update(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'current_password' => ['required', 'current_password'],
+            'password' => ['required', Password::defaults(), 'confirmed'],
+        ]);
+
+        $request->user()->update([
+            'password' => Hash::make($validated['password']),
+        ]);
+
+        return back();
+    }
+}

--- a/backend/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/backend/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class PasswordResetLinkController extends Controller
+{
+    /**
+     * Display the password reset link request view.
+     */
+    public function create(): Response
+    {
+        return Inertia::render('Auth/ForgotPassword', [
+            'status' => session('status'),
+        ]);
+    }
+
+    /**
+     * Handle an incoming password reset link request.
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'email' => 'required|email',
+        ]);
+
+        // We will send the password reset link to this user. Once we have attempted
+        // to send the link, we will examine the response then see the message we
+        // need to show to the user. Finally, we'll send out a proper response.
+        $status = Password::sendResetLink(
+            $request->only('email')
+        );
+
+        if ($status == Password::RESET_LINK_SENT) {
+            return back()->with('status', __($status));
+        }
+
+        throw ValidationException::withMessages([
+            'email' => [trans($status)],
+        ]);
+    }
+}

--- a/backend/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/backend/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class RegisteredUserController extends Controller
+{
+    /**
+     * Display the registration view.
+     */
+    public function create(): Response
+    {
+        return Inertia::render('Auth/Register');
+    }
+
+    /**
+     * Handle an incoming registration request.
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|string|lowercase|email|max:255|unique:'.User::class,
+            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+        ]);
+
+        $user = User::create([
+            'name' => $request->name,
+            'email' => $request->email,
+            'password' => Hash::make($request->password),
+        ]);
+
+        event(new Registered($user));
+
+        Auth::login($user);
+
+        return redirect(route('dashboard', absolute: false));
+    }
+}

--- a/backend/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/backend/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Auth\Events\Verified;
+use Illuminate\Foundation\Auth\EmailVerificationRequest;
+use Illuminate\Http\RedirectResponse;
+
+class VerifyEmailController extends Controller
+{
+    /**
+     * Mark the authenticated user's email address as verified.
+     */
+    public function __invoke(EmailVerificationRequest $request): RedirectResponse
+    {
+        if ($request->user()->hasVerifiedEmail()) {
+            return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
+        }
+
+        if ($request->user()->markEmailAsVerified()) {
+            event(new Verified($request->user()));
+        }
+
+        return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
+    }
+}

--- a/backend/app/Http/Controllers/MCityController.php
+++ b/backend/app/Http/Controllers/MCityController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\MCity;
+
+class MCityController extends Controller
+{
+    public function getByPrefecture($prefecture)
+    {
+        $citys = MCity::where('prefectures_id', $prefecture)->get();
+        return response()->json($citys);
+    }
+}

--- a/backend/app/Http/Controllers/MPositionController.php
+++ b/backend/app/Http/Controllers/MPositionController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class MPositionController extends Controller
+{
+    //
+}

--- a/backend/app/Http/Controllers/MPrefectureController.php
+++ b/backend/app/Http/Controllers/MPrefectureController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\MPrefecture;
+
+class MPrefectureController extends Controller
+{
+    //
+}

--- a/backend/app/Http/Controllers/MTeamController.php
+++ b/backend/app/Http/Controllers/MTeamController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\MTeam;
+use Inertia\Inertia; //vue導入で必要
+
+class MTeamController extends Controller
+{
+    //
+    public function index() {
+        $teams = MTeam::all();
+        //return view('teams.index' , compact('teams'));
+        return Inertia::render('Teams/Index',['teams' => $teams,]);
+    }
+
+    public function show($team_id){
+        $team = MTeam::findOrFail($team_id);
+        //return view('teams.show', compact('team'));
+        return Inertia::render('Teams/Show',['team' => $team,]);
+    }
+
+    //public function players($team_id){
+    //    $team = MTeam::findOrFail($id);
+    //    $players = TPlayer::where('team_id', $team_id)->get();
+    //    return view('teams.players', compact('players, team'));
+    //}
+}

--- a/backend/app/Http/Controllers/ProfileController.php
+++ b/backend/app/Http/Controllers/ProfileController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\ProfileUpdateRequest;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Redirect;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ProfileController extends Controller
+{
+    /**
+     * Display the user's profile form.
+     */
+    public function edit(Request $request): Response
+    {
+        return Inertia::render('Profile/Edit', [
+            'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,
+            'status' => session('status'),
+        ]);
+    }
+
+    /**
+     * Update the user's profile information.
+     */
+    public function update(ProfileUpdateRequest $request): RedirectResponse
+    {
+        $request->user()->fill($request->validated());
+
+        if ($request->user()->isDirty('email')) {
+            $request->user()->email_verified_at = null;
+        }
+
+        $request->user()->save();
+
+        return Redirect::route('profile.edit');
+    }
+
+    /**
+     * Delete the user's account.
+     */
+    public function destroy(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'password' => ['required', 'current_password'],
+        ]);
+
+        $user = $request->user();
+
+        Auth::logout();
+
+        $user->delete();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return Redirect::to('/');
+    }
+}

--- a/backend/app/Http/Controllers/TFavoriteController.php
+++ b/backend/app/Http/Controllers/TFavoriteController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\TFavorite;
+use Inertia\Inertia;
+use Illuminate\Support\Facades\Auth;
+
+class TFavoriteController extends Controller
+{
+    //
+    public function index(){
+        $user = Auth::user();
+
+        $players = $user->favoritePlayers()
+        ->with('team')
+        ->get();
+
+        return Inertia::render('Players/Favorites', [ 'players' => $players ]);
+    }
+}

--- a/backend/app/Http/Controllers/TPlayerController.php
+++ b/backend/app/Http/Controllers/TPlayerController.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\TPlayer;
+use App\Models\MTeam;
+use App\Models\MPosition;
+use App\Models\MPrefecture;
+use App\Models\MCity;
+use Inertia\Inertia;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+
+class TPlayerController extends Controller
+{
+    //
+    public function index($team_id){
+        $players = TPlayer::with('position')->where('team_id', $team_id)->get();
+        $team = MTeam::findOrFail($team_id);
+        //return view('players.index', compact('players', 'team'));
+        return Inertia::render('Players/Index', ['players' => $players, 'team' => $team]);
+    }
+
+    public function create($team_id){
+        $team = MTeam::findOrFail($team_id);
+        $positions = MPosition::all();
+        $prefectures = MPrefecture::all();
+        $citys = MCity::all();
+        //return view('players.create', compact('team', 'positions', 'prefectures', 'citys'));
+        return Inertia::render('Players/Create', ['team' => $team, 'positions' => $positions, 'prefectures' => $prefectures, 'citys' => $citys]);
+    }
+
+    public function store(Request $request, $team_id){      
+        //バリテーション
+        $validated  = $request->validate([
+            'name' => 'required|string|max:255',
+            'position_id' => 'required|integer|max:9',
+            'uniform_no' => [
+                'required',
+                'max:10',
+                Rule::unique('t_players')->where(function($query) use($request, $team_id) {
+                    return $query->where('name', $request->name)
+                                ->where('team_id', $team_id);
+                }),
+            ],
+            'highschool' => 'nullable|string|max:255',
+            'university' => 'nullable|string|max:255',
+            'company' => 'nullable|string|max:255',
+            'birthday' => 'required|date',
+            'prefecture_id' => 'nullable|integer|max:47',
+            'city_id' => 'nullable|integer|max:1892',
+        ], [
+        'uniform_no.unique' => 'この選手名と背番号の組み合わせはすでに登録されています。',
+        ]);
+
+        //team_idは固定なので後から追加
+        $validated['team_id'] = $team_id;
+        $validated['birthday'] = \Carbon\Carbon::parse($validated['birthday'])->format('Y-m-d');
+
+        TPlayer::create($validated);
+
+        return redirect()->route('players.index', ['team_id' => $team_id])
+            ->with('success', '選手が登録されました。');
+    }
+
+    public function show($team_id, $player_id){
+        $player = TPlayer::with(['position', 'team', 'prefecture', 'city'])
+            ->where('team_id', $team_id)
+            ->withCount(['favoredByUsers as is_favorite' => function($query) {
+            $query->where('user_id', Auth::id());
+        }])
+            ->findOrFail($player_id);
+        
+        $team = MTeam::findOrFail($team_id);
+
+        //return view('players.show', compact('team', 'player'));
+        return Inertia::render('Players/Show', ['team' => $team, 'player' => $player]);
+    }   
+
+    public function edit($team_id, $player_id){
+        $player = TPlayer::with(['position', 'team', 'prefecture', 'city'])
+            ->where('team_id', $team_id)
+            ->findOrFail($player_id);
+            
+        $team = MTeam::findOrFail($team_id);
+
+        $positions = MPosition::all();
+        $prefectures =Mprefecture::all();
+        $citys = MCity::all();
+
+        //return view('players.edit', compact('player', 'team', 'positions', 'prefectures', 'citys'));
+        return Inertia::render('Players/Edit', ['player' => $player, 'team' => $team, 'positions' => $positions, 'prefectures' => $prefectures, 'citys' => $citys]);
+    }
+
+    public function update(Request $request, $team_id, $player_id){
+
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'position_id' => 'required|integer|max:9',
+            'uniform_no' => [
+                'required',
+                'max:10',
+                Rule::unique('t_players')->where(function ($query) use($request, $team_id) {
+                    return $query->where('name', $request->name)
+                                ->where('team_id', $team_id);
+                })->ignore($player_id),
+            ],
+            'highschool' => 'nullable|string|max:255',
+            'university' => 'nullable|string|max:255',
+            'birthday' => 'nullable|date',
+            'prefecture_id' => 'nullable|integer|max:47',
+            'city_id' => 'nullable|integer|max:1892',
+        ], [
+                'uniform_no.unique' => 'この選手名と背番号の組み合わせはすでに登録されています。',
+            ]);
+
+        $request['birthday'] = \Carbon\Carbon::parse($request['birthday'])->format('Y-m-d');
+
+        $player = TPlayer::where('team_id', $team_id)->findOrFail($player_id);
+
+        $player->update($request->all());
+
+        return redirect()->route('players.show', ['team_id' => $team_id, 'player_id' => $player_id])
+            ->with('success', '選手情報を更新しました。');
+    }
+
+    public function destroy($team_id, $player_id){
+        $player = TPlayer::where('team_id', $team_id)->findOrFail($player_id);
+        $player->delete();
+
+        return redirect()->route('players.index', ['team_id' => $team_id])
+            ->with('success', '選手情報が削除されました。');
+    }
+
+    public function restore($team_id, $player_id){
+        $player = TPlayer::onlyTrashed()
+            ->where('team_id', $team_id)
+            ->where('id', $player_id)
+            ->firstOrFail();
+            
+        $player->restore();
+
+        return redirect()->route('players.deleted', ['team_id' => $team_id])
+            ->with('success', '選手情報を復元しました。');
+    }
+
+    public function deleted($team_id){
+        $players = TPlayer::onlyTrashed()->where('team_id', $team_id)->get();
+        //return view('players.deleted', compact('players', 'team_id'));
+        return Inertia::render('Players/Deleted', ['players' => $players, 'team_id' => $team_id]);
+    }
+
+    public function toggleFavorite($team_id, $player_id){
+        $user = Auth::user();
+
+        $player = TPlayer::where('team_id', $team_id)->findOrFail($player_id);
+
+        //すでにお気に入りに登録されているかチェック
+        $exists = $user->favoritePlayers()->where('player_id', $player_id)->exists();
+
+        if($exists){
+            $user->favoritePlayers()->detach($player_id);
+            $favorited = false;
+        } else {
+            $user->favoritePlayers()->attach($player_id);
+            $favorited = true;
+        }
+
+        return response()->json(['is_favorite' => $favorited]);
+    }
+
+}

--- a/backend/app/Models/MCity.php
+++ b/backend/app/Models/MCity.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MCity extends Model
+{
+    //
+    protected $table = 'm_citys';
+
+    public $timestamps = false;
+
+    protected $fillable = ['name', 'prefectures_id'];
+
+    public function players(){
+        return $this->hasMany(TPlayer::class, 'city_id');
+    }
+}

--- a/backend/app/Models/MPosition.php
+++ b/backend/app/Models/MPosition.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MPosition extends Model
+{
+    //
+    protected $table = 'm_positions';
+    
+    public $timestamps = false;
+
+    protected $fillable = ['name'];
+
+    //TPlayerとのリレーション
+    //Position 1 に属するプレイヤーが複数いる場合、このリレーションで
+    //position->players で全プレイヤーが取得できる。
+    public function players() {
+        return $this->hasMany(TPlayer::class, 'position_id');
+    }
+}

--- a/backend/app/Models/MPrefecture.php
+++ b/backend/app/Models/MPrefecture.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MPrefecture extends Model
+{
+    //
+    protected $table = 'm_prefectures';
+
+    public $timestamps = false;
+
+    protected $fillable = ['name'];
+
+    public function players(){
+        return $this->hasMany(TPlayer::class, 'prefecture_id');
+    }
+}

--- a/backend/app/Models/MTeam.php
+++ b/backend/app/Models/MTeam.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MTeam extends Model
+{
+    //
+    protected $table = 'm_teams'; //つけないとDB誤認するかも。
+    
+    public $timestamps = false;
+
+    protected $fillable = ['name'];
+    
+    public function players(){
+        return $this->hasMany(TPlayer::class, 'team_id');
+    }
+}

--- a/backend/app/Models/TFavorite.php
+++ b/backend/app/Models/TFavorite.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TFavorite extends Model
+{
+    //
+}

--- a/backend/app/Models/TPlayer.php
+++ b/backend/app/Models/TPlayer.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Models\MPosition;
+use App\Models\MTeam;
+use App\Models\MPrefecture;
+use App\Models\MCity;
+
+class TPlayer extends Model
+{
+    //
+    protected $table = 't_players';
+
+    public function position(){
+        return $this->belongsTo(MPosition::class, 'position_id');
+    }
+
+    public function team(){
+        return $this->belongsTo(MTeam::class, 'team_id');
+    }
+
+    public function prefecture(){
+        return $this->belongsTo(MPrefecture::class, 'prefecture_id');
+    }
+
+    public function city(){
+        return $this->belongsTo(MCity::class, 'city_id');
+    }
+
+    protected $fillable = [
+        'name',
+        'position_id',
+        'uniform_no',
+        'team_id',
+        'highschool',
+        'university',
+        'company',
+        'birthday',
+        'prefecture_id',
+        'city_id',
+        'is_favorite',
+    ];
+
+    protected $casts = [
+        'is_favorite' => 'boolean',
+    ];
+
+    use SoftDeletes;
+    protected $dates = ['deleted_at'];
+
+    public function favoredByUsers (){
+        return $this->belongsToMany(User::class, 't_favorite_players', 'player_id', 'user_id')->withTimestamps();
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Http\Controllers\MCityController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('prefectures/{prefecture}/citys', [MCityController::class, 'getByPrefecture']);

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,7 +1,45 @@
 <?php
 
+use App\Http\Controllers\MTeamController;
+use App\Http\Controllers\MPlayerController;
+use App\Http\Controllers\TPlayerController;
+use App\Http\Controllers\TFavoriteController;
+use App\Http\Controllers\ProfileController;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+
 
 Route::get('/', function () {
-    return view('welcome');
+    return Inertia::render('Dashboard');
+})->middleware(['auth', 'verified'])->name('dashboard');
+
+Route::middleware('auth')->group(function () {
+    Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
+    Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
+    Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
+
+Route::get('/top', function () {
+    return view('top');
+}) -> name('top');
+
+//MTeam
+Route::get('/teams', [MTeamController::class, 'index'])->name('teams.index');
+Route::get('/teams/{team_id}', [MTeamController::class, 'show'])->name('teams.show');
+
+//TPlayer
+Route::get('/teams/{team_id}/players', [TPlayerController::class, 'index'])->name('players.index');
+Route::get('/teams/{team_id}/players/create', [TPlayerController::class, 'create'])->name('players.create');
+Route::post('/teams/{team_id}/players', [TPlayerController::class, 'store'])->name('players.store');
+Route::get('/teams/{team_id}/players/deleted', [TPlayerController::class, 'deleted'])->name('players.deleted');
+Route::get('/teams/{team_id}/players/{player_id}', [TPlayerController::class, 'show'])->name('players.show');
+Route::get('/teams/{team_id}/players/{player_id}/edit', [TPlayerController::class, 'edit'])->name('players.edit');
+Route::put('/teams/{team_id}/players/{player_id}', [TPlayerController::class, 'update'])->name('players.update');
+Route::delete('/teams/{team_id}/players/{player_id}', [TPlayerController::class, 'destroy'])->name('players.destroy');
+Route::post('/teams/{team_id}/players/{player_id}/restore', [TPlayerController::class, 'restore'])->name('players.restore');
+
+Route::post('/teams/{team_id}/players/{player_id}/favorite', [TPlayerController::class, 'toggleFavorite'])->middleware('auth')->name('players.favorite');
+Route::get('/favorites', [TFavoriteController::class, 'index'])->middleware('auth')->name('favorites.index');
+
+require __DIR__.'/auth.php';


### PR DESCRIPTION
## 概要  
NPB選手・チーム情報管理のためのコントローラ・モデル・ルーティングを追加しました。  

---

## 主な変更点  

### 🔒 認証関連（旧式のnpb-directory-Laravelからコピペ）
- `Auth/AuthenticatedSessionController` など、9つの認証用コントローラを追加
- `routes/web.php` に Inertia 対応のルートを設定（`auth.php`読み込み含む）

### 🧩 業務用コントローラ追加  
- `MTeamController`, `TPlayerController`, `TFavoriteController`, `MCityController` などを作成
- チーム・選手のCRUD、削除済み表示、復元、お気に入り登録などに対応

### 🧬 モデル追加  
- `MTeam`, `TPlayer`, `TFavorite`, `MCity`, `MPrefecture`, `MPosition` などのモデルを定義

---

## その他  
- 今後、Vue SPA（Inertia）との連携を本格化させるための基盤準備
- 必要に応じてAPIルート（`api.php`）側への移行も検討予定
