### PR TITLE
ルーティング構造の見直し・整理

### DIFF
--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,10 +1,15 @@
 <?php
 
+use App\Http\Controllers\MTeamController;
+use App\Http\Controllers\MPlayerController;
+use App\Http\Controllers\TPlayerController;
+use App\Http\Controllers\TFavoriteController;
 use App\Http\Controllers\ProfileController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
+/*
 Route::get('/', function () {
     return Inertia::render('Welcome', [
         'canLogin' => Route::has('login'),
@@ -13,8 +18,9 @@ Route::get('/', function () {
         'phpVersion' => PHP_VERSION,
     ]);
 });
+*/
 
-Route::get('/dashboard', function () {
+Route::get('/', function () {
     return Inertia::render('Dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');
 
@@ -23,5 +29,27 @@ Route::middleware('auth')->group(function () {
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
+
+Route::get('/top', function () {
+    return view('top');
+}) -> name('top');
+
+//MTeam
+Route::get('/teams', [MTeamController::class, 'index'])->name('teams.index');
+Route::get('/teams/{team_id}', [MTeamController::class, 'show'])->name('teams.show');
+
+//TPlayer
+Route::get('/teams/{team_id}/players', [TPlayerController::class, 'index'])->name('players.index');
+Route::get('/teams/{team_id}/players/create', [TPlayerController::class, 'create'])->name('players.create');
+Route::post('/teams/{team_id}/players', [TPlayerController::class, 'store'])->name('players.store');
+Route::get('/teams/{team_id}/players/deleted', [TPlayerController::class, 'deleted'])->name('players.deleted');
+Route::get('/teams/{team_id}/players/{player_id}', [TPlayerController::class, 'show'])->name('players.show');
+Route::get('/teams/{team_id}/players/{player_id}/edit', [TPlayerController::class, 'edit'])->name('players.edit');
+Route::put('/teams/{team_id}/players/{player_id}', [TPlayerController::class, 'update'])->name('players.update');
+Route::delete('/teams/{team_id}/players/{player_id}', [TPlayerController::class, 'destroy'])->name('players.destroy');
+Route::post('/teams/{team_id}/players/{player_id}/restore', [TPlayerController::class, 'restore'])->name('players.restore');
+
+Route::post('/teams/{team_id}/players/{player_id}/favorite', [TPlayerController::class, 'toggleFavorite'])->middleware('auth')->name('players.favorite');
+Route::get('/favorites', [TFavoriteController::class, 'index'])->middleware('auth')->name('favorites.index');
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## 概要
ルーティング構造の見直し・整理を行いました。

## 主な変更内容
- `routes/web.php` と `routes/api.php` の役割を明確に分離
    - 画面描画・Inertia.js経由のルートは `web.php` へ統一
    - JSON APIとして提供するエンドポイントは `api.php` へ分離
- コントローラごとにルートの配置を見直し
    - `TPlayerController` など画面遷移・リダイレクトを伴う処理は `web.php` に定義
    - 都道府県→市区町村取得APIなど、純粋なデータAPIは `api.php` に定義
- ミドルウェア（`auth` など）の付与ルールを整理
- ルート名(route name)の一貫性・命名規則を統一

## 目的
- 役割ごとにルーティングを整理し、保守性・拡張性を向上させるため
- フロント(Vue/Inertia.js)とバックエンドの連携を明確化
